### PR TITLE
add ouxt_behavior_descriptor package

### DIFF
--- a/packages.yaml
+++ b/packages.yaml
@@ -57,6 +57,9 @@ ros:
       rosdistro:
         - foxy
     message_synchronizer:
+    ouxt_behavior_descriptor_v1:
+      rosdistro:
+        - foxy
 others:
   OUXT-Polaris:
     robotx_setup:


### PR DESCRIPTION
Signed-off-by: Masaya Kataoka <ms.kataoka@gmail.com>

add ouxt_behavior_descriptor package to the packages.yaml